### PR TITLE
Fix SRT Ports docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,10 @@ services:
     environment:
       - LANG=en
       - TZ=UTC
-      - SLS_API_URL=http://localhost:8789
+      - SLS_API_URL=http://srtla-server:8789
       - SLS_API_KEY=yourapikey
-      - SRT_PUBLISH_PORT=4000
-      - SRT_PLAYER_PORT=4001
+      - SRT_PUBLISH_PORT=4001
+      - SRT_PLAYER_PORT=4000
       - SRTLA_PUBLISH_PORT=5000
       - SLS_DOMAIN_IP=localhost
       - SLS_STATS_PORT=8789

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       - LANG=en
       - TZ=UTC
-      - SLS_API_URL=http://srtla-server:8789
+      - SLS_API_URL=http://srtla-server:8080
       - SLS_API_KEY=yourapikey
       - SRT_PUBLISH_PORT=4001
       - SRT_PLAYER_PORT=4000


### PR DESCRIPTION
SRT Ports in slspanel getauscht, damit diese korrekt sind und SLS_API_URL auf den Container-Namen gewechselt, damit die Verbindung intern läuft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SLS API service connectivity.
  * Corrected SRT publishing and playback port assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->